### PR TITLE
support gap bwtween line number and code and support 100% width

### DIFF
--- a/lovelace.typ
+++ b/lovelace.typ
@@ -110,6 +110,7 @@
   line-numbering: "1",
   line-number-supplement: "Line",
   stroke: 1pt + gray,
+  code-offset: .5em,
   indentation: 1em,
   hooks: 0pt,
   line-gap: .8em,
@@ -267,10 +268,14 @@
       ),
     ),
   )
-
+  let line-number-x = if line-numbering == none { -1 } else { 0 }
   grid(
     columns: max-x + 1 + line-number-correction,
-    column-gutter: indentation / 2,
+    inset: (x, y) => {
+      if x == line-number-x or y == 0 { (:) }
+      else if x == line-number-x + 1 { (left: code-offset) }
+      else { (left: indentation) }
+    },
     row-gutter: line-gap,
     ..cells,
     ..decoration,


### PR DESCRIPTION
Hi Andreas,  I would like to extend my heartfelt thanks to the Lovelace package, which has been instrumental in completing my master thesis.

I noticed a small issue that It does not make full use of 100% page width.  For example, when I use `#h(1fr)`, it still exists a gap with the edge of the page.

```typ
#block(
  fill: luma(230),
  [#lorem(30) #h(1fr)],
)

#line(length: 100%)

#figure(
  kind: "algorithm",
  supplement: [Algorithm],
  pseudocode-list(booktabs: true, numbered-title: [My cool algorithm #h(1fr)],
  indentation: 1em,
  stroke: none,
  )[
    + do something
    + do something else
    + *while* still something to do
      + do even more
      + *if* not done yet *then*
        + wait a bit
        + resume working
      + *else*
        + go home
      + *end*
    + *end*
  ]
)
```

![image](https://github.com/user-attachments/assets/f60dbc2d-7f73-4568-b6b4-d7b8bafcec35)



I find it is affected by the parameter `indentation` .  When `indentation` is `0em`, there is no gap, but the code indents become weird.


![image](https://github.com/user-attachments/assets/587f03da-9966-4f3d-868f-95211941e0f0)



When `indentation` is a non-zero value, the algorithm width is affected.

**2em:**
![image](https://github.com/user-attachments/assets/8e9cec55-f9c6-498f-b3e1-1e4c071a3340)

**5em:**
![image](https://github.com/user-attachments/assets/d2ee60b1-6ece-4dae-84b0-3e0e2c2cfe5a)


I have fixed this issue and added a parameter `code-offset` to specify the gap between the line numbers and the code. The width is not affected by the parameter `indentation`  and that the code is indented correctly.

```typ
#block(
  fill: luma(230),
  [#lorem(30) #h(1fr)],
)

#line(length: 100%)

#figure(
  kind: "algorithm",
  supplement: [Algorithm],
  pseudocode-list(booktabs: true, numbered-title: [My cool algorithm #h(1fr)],
  indentation: 1em,
  code-offset: .5em,
  stroke: none,
  )[
    + do something
    + do something else
    + *while* still something to do
      + do even more
      + *if* not done yet *then*
        + wait a bit
        + resume working
      + *else*
        + go home
      + *end*
    + *end*
  ]
)
```

![image](https://github.com/user-attachments/assets/69544bc5-9f04-4c4a-b88c-00b836d76f49)

`indentation` is set to `2em`:

![image](https://github.com/user-attachments/assets/d4908b29-ed41-4dc5-a02c-f34ead5efc7c)


`code-offset` is set to `2em`:

![image](https://github.com/user-attachments/assets/aba63d76-523f-43dc-a002-49a71ea2780d)


I'm a typst beginner, please feel free to give me advice.

